### PR TITLE
HomeKit: single path for position EVENT push

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -194,6 +194,11 @@ The controller lock is the application-level ordering rule. Driver locks are int
 
 Selection notifications and position broadcasts are separate from operation and hardware locks, so observers can continue receiving state while a command is queued or executing.
 
+Live state uses two notification channels:
+
+- **Selection** — `watch` from the active driver through `BlindController::subscribe_selection()`; consumed by SSE `/events` and WebSocket.
+- **Positions** — `broadcast` from `BlindController` after inferred moves and timed HomeKit motion; consumed by tests via `subscribe_positions()`. When HomeKit is enabled, `homekit::start` installs a hook on the same emit path to translate deltas into HAP `CharacteristicEvent` frames (no background listener task).
+
 These locks are correctness mechanisms, not trust boundaries. They prevent malformed timing and state races; they do not authenticate clients.
 
 ## Persistence

--- a/docs/HAP.md
+++ b/docs/HAP.md
@@ -57,7 +57,7 @@ Both files are written atomically (tmp + `rename`) with mode `0600`. systemd pre
 
 1. **Plain phase** — `POST /pair-setup`, `POST /pair-verify`. After M4 verifies, the reader/writer are upgraded to encrypted halves and the connection switches to the control channel.
 2. **Control phase** — `GET /accessories`, `GET /characteristics`, `PUT /characteristics`, `POST /pairings`. All require an encrypted writer; otherwise we return `401`.
-3. **Event push** — every connection holds a per-socket `HashSet<(aid, iid)>` of subscribed characteristics and a `broadcast::Receiver<Vec<CharacteristicEvent>>`. The controller emits target/moving events immediately and completion events after the timed move; subscribers fan them out as `EVENT/1.0` frames over the same encrypted writer.
+3. **Event push** — every connection holds a per-socket `HashSet<(aid, iid)>` of subscribed characteristics and a `broadcast::Receiver<Vec<CharacteristicEvent>>`. When the controller publishes position deltas, a hook installed at `homekit::start` maps them to characteristic events on that broadcast channel; HAP connections fan matching subscriptions out as `EVENT/1.0` frames over the same encrypted writer.
 
 EVENT push is what resolves the iOS "Closing…" / "Opening…" spinner (waits on `PositionState=2` + `CurrentPosition` matching `TargetPosition`) and what keeps grouped Home writes reflected on each individual blind tile.
 
@@ -67,7 +67,7 @@ EVENT push is what resolves the iOS "Closing…" / "Opening…" spinner (waits o
 
 - `{aid, iid, ev: true|false}` — toggle subscription on the per-connection set. No GPIO action.
 - `{aid, iid, value: N}` where `N` matches the estimated current position — no-op unless it cancels a pending timed move, in which case the controller sends `stop`.
-- `{aid, iid, value: N}` with a real change — asks the shared controller to move from the estimated current position to `N`. The controller sends `up` or `down`, emits `TargetPosition` plus moving `PositionState`, and for interior targets (`1..99`) sends `stop` after the configured proportional travel time. Endpoint targets (`0` or `100`) rely on the motor's own limits. Completion updates `CurrentPosition`, persists `positions.json`, and emits stopped events.
+- `{aid, iid, value: N}` with a real change — asks the shared controller to move from the estimated current position to `N`. The controller sends `up` or `down`, emits `TargetPosition` plus moving `PositionState`, and for interior targets (`1..99`) sends `stop` after the configured proportional travel time. Endpoint targets (`0` or `100`) rely on the motor's own limits. Completion updates `CurrentPosition`, persists `positions.json`, and emits stopped events. HAP EVENT frames for those updates are published only from the controller position hook (not duplicated on the PUT write outcome).
 
 ## Timed positioning
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::fmt;
+use std::sync::{Arc, Mutex as StdMutex};
 use tokio::sync::{broadcast, Mutex};
 
 use crate::config::{DriverKind, PositioningOptions};
@@ -9,8 +10,9 @@ use crate::driver::{CommandOutcome, CommandRouter, SelectedChannelRx};
 use crate::positioning::motion::{plan_motion, BlindMovement, MotionRequest, MotionTimings};
 use crate::positioning::state::{find_blind, BlindPosition, PositionCache, PositionDelta, BLINDS};
 
+type PositionHook = Arc<dyn Fn(Vec<PositionDelta>) + Send + Sync>;
+
 /// Driver-agnostic control of channel selection, button presses, and position events.
-#[derive(Debug)]
 pub struct BlindController {
     router: CommandRouter,
     driver_kind: DriverKind,
@@ -18,8 +20,24 @@ pub struct BlindController {
     positions: Arc<PositionCache>,
     timings: MotionTimings,
     motion_tasks: MotionTasks,
-    /// Fan-out of position target/current changes for HomeKit and future API clients.
+    /// Fan-out of position target/current changes for tests and future API clients.
     position_tx: broadcast::Sender<Vec<PositionDelta>>,
+    /// Installed by `homekit::start` to push HAP EVENT frames without a background task.
+    position_hook: StdMutex<Option<PositionHook>>,
+}
+
+impl fmt::Debug for BlindController {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hook_attached = self
+            .position_hook
+            .lock()
+            .map(|hook| hook.is_some())
+            .unwrap_or(false);
+        f.debug_struct("BlindController")
+            .field("driver_kind", &self.driver_kind)
+            .field("position_hook_attached", &hook_attached)
+            .finish_non_exhaustive()
+    }
 }
 
 impl BlindController {
@@ -38,7 +56,16 @@ impl BlindController {
             timings: positioning.into(),
             motion_tasks: MotionTasks::default(),
             position_tx,
+            position_hook: StdMutex::new(None),
         })
+    }
+
+    /// Wire position deltas to a side channel (e.g. HomeKit EVENT push). Call once at startup.
+    pub fn attach_position_hook(&self, hook: PositionHook) {
+        match self.position_hook.lock() {
+            Ok(mut guard) => *guard = Some(hook),
+            Err(_) => tracing::warn!("position hook mutex poisoned; HomeKit events disabled"),
+        }
     }
 
     #[cfg(test)]
@@ -58,6 +85,7 @@ impl BlindController {
             timings: positioning.into(),
             motion_tasks: MotionTasks::default(),
             position_tx,
+            position_hook: StdMutex::new(None),
         })
     }
 
@@ -76,9 +104,22 @@ impl BlindController {
         self.router.subscribe_selected_channel()
     }
 
-    /// Subscribe to target/current position changes.
+    /// Subscribe to target/current position changes (tests; future API clients).
+    #[cfg(test)]
     pub fn subscribe_positions(&self) -> broadcast::Receiver<Vec<PositionDelta>> {
         self.position_tx.subscribe()
+    }
+
+    fn emit_position_deltas(&self, deltas: Vec<PositionDelta>) {
+        if deltas.is_empty() {
+            return;
+        }
+        if let Ok(guard) = self.position_hook.lock() {
+            if let Some(hook) = guard.as_ref() {
+                hook(deltas.clone());
+            }
+        }
+        let _ = self.position_tx.send(deltas);
     }
 
     pub async fn position_snapshot(&self) -> Vec<BlindPosition> {
@@ -137,9 +178,7 @@ impl BlindController {
                     );
                 }
             }
-            if !deltas.is_empty() {
-                let _ = self.position_tx.send(deltas.clone());
-            }
+            self.emit_position_deltas(deltas.clone());
             return Ok(deltas);
         }
 
@@ -160,9 +199,7 @@ impl BlindController {
             );
             self.schedule_completion(movement).await;
         }
-        if !deltas.is_empty() {
-            let _ = self.position_tx.send(deltas.clone());
-        }
+        self.emit_position_deltas(deltas.clone());
         Ok(deltas)
     }
 
@@ -220,9 +257,7 @@ impl BlindController {
         if let Some(position) = inferred_position {
             self.motion_tasks.cancel_channel(channel).await;
             let deltas = self.positions.apply_for_channel(channel, position).await;
-            if !deltas.is_empty() {
-                let _ = self.position_tx.send(deltas);
-            }
+            self.emit_position_deltas(deltas);
         }
         CommandOutcome { inferred_position }
     }
@@ -265,9 +300,7 @@ impl BlindController {
                 .positions
                 .apply_blind_current(movement.blind, movement.target)
                 .await;
-            if !deltas.is_empty() {
-                let _ = controller.position_tx.send(deltas);
-            }
+            controller.emit_position_deltas(deltas);
             controller
                 .motion_tasks
                 .remove_if_current(movement.blind.aid, generation)

--- a/src/homekit/mod.rs
+++ b/src/homekit/mod.rs
@@ -6,8 +6,9 @@ use tokio::sync::broadcast;
 
 use crate::controller::BlindController;
 use crate::hap::mdns::{self, MdnsConfig};
-use crate::hap::runtime::HapRuntime;
+use crate::hap::runtime::{CharacteristicEvent, HapRuntime};
 use crate::hap::state::{FileHapStore, HapState};
+use crate::positioning::state::PositionDelta;
 
 mod accessory_db;
 pub mod somfy;
@@ -30,13 +31,11 @@ pub fn setup_uri(state: &HapState) -> Result<String> {
 /// Handles for the background HomeKit tasks started by [`start`].
 pub struct HomekitHandles {
     _announcement: mdns::Announcement,
-    position_listener: tokio::task::JoinHandle<()>,
     hap_server: tokio::task::JoinHandle<()>,
 }
 
 impl HomekitHandles {
     pub fn abort(&self) {
-        self.position_listener.abort();
         self.hap_server.abort();
     }
 }
@@ -60,14 +59,10 @@ pub async fn start(controller: Arc<BlindController>) -> Result<HomekitHandles> {
     )?;
 
     let (events, _) = broadcast::channel(64);
-    let position_rx = controller.subscribe_positions();
-    let app = Arc::new(somfy::SomfyHapApp::new(controller));
-    let runtime = Arc::new(HapRuntime::new(hap_state, store, app.clone(), events));
+    let app = Arc::new(somfy::SomfyHapApp::new(controller.clone()));
+    let runtime = Arc::new(HapRuntime::new(hap_state, store, app, events));
 
-    let event_tx = runtime.event_sender();
-    let position_listener = tokio::spawn(async move {
-        app.run_position_listener(event_tx, position_rx).await;
-    });
+    attach_hap_position_events(&controller, runtime.event_sender());
 
     let hap_server = tokio::spawn(async move {
         if let Err(e) = crate::hap::server::serve(runtime, HAP_PORT).await {
@@ -76,7 +71,19 @@ pub async fn start(controller: Arc<BlindController>) -> Result<HomekitHandles> {
     });
     Ok(HomekitHandles {
         _announcement: announcement,
-        position_listener,
         hap_server,
     })
+}
+
+fn attach_hap_position_events(
+    controller: &BlindController,
+    event_tx: broadcast::Sender<Vec<CharacteristicEvent>>,
+) {
+    controller.attach_position_hook(Arc::new(move |deltas: Vec<PositionDelta>| {
+        let events = somfy::position_characteristic_events(&deltas);
+        if !events.is_empty() {
+            tracing::debug!(count = events.len(), "hap position events published");
+            let _ = event_tx.send(events);
+        }
+    }));
 }

--- a/src/homekit/somfy.rs
+++ b/src/homekit/somfy.rs
@@ -5,7 +5,6 @@
 use anyhow::anyhow;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::broadcast;
 
 use crate::controller::BlindController;
 use crate::hap::runtime::{
@@ -35,33 +34,8 @@ impl SomfyHapApp {
         Self { controller }
     }
 
-    pub async fn run_position_listener(
-        self: Arc<Self>,
-        event_tx: broadcast::Sender<Vec<CharacteristicEvent>>,
-        mut rx: broadcast::Receiver<Vec<PositionDelta>>,
-    ) {
-        loop {
-            match rx.recv().await {
-                Ok(deltas) => {
-                    let events = characteristic_events(&deltas);
-                    if !events.is_empty() {
-                        let _ = event_tx.send(events);
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!("position listener lagged by {n}");
-                }
-                Err(broadcast::error::RecvError::Closed) => break,
-            }
-        }
-    }
-
-    async fn execute_targets(
-        &self,
-        targets: &[PendingTargetWrite],
-    ) -> Result<Vec<CharacteristicEvent>, anyhow::Error> {
-        let deltas = self
-            .controller
+    async fn execute_targets(&self, targets: &[PendingTargetWrite]) -> Result<(), anyhow::Error> {
+        self.controller
             .set_target_positions(
                 targets
                     .iter()
@@ -69,12 +43,13 @@ impl SomfyHapApp {
                     .collect(),
             )
             .await
-            .map_err(|e| anyhow!(e))?;
-        Ok(characteristic_events(&deltas))
+            .map(|_| ())
+            .map_err(|e| anyhow!(e))
     }
 }
 
-fn characteristic_events(deltas: &[PositionDelta]) -> Vec<CharacteristicEvent> {
+/// Map controller position deltas to HAP characteristic events for EVENT push.
+pub(crate) fn position_characteristic_events(deltas: &[PositionDelta]) -> Vec<CharacteristicEvent> {
     let mut events = Vec::new();
     for delta in deltas {
         if let Some(current) = delta.current {
@@ -131,9 +106,8 @@ impl HapAccessoryApp for SomfyHapApp {
             let mut outcome = CharacteristicWriteOutcome::default();
             let mut statuses = plan.statuses;
 
-            outcome
-                .events
-                .extend(self.execute_targets(&plan.targets).await?);
+            // Position EVENT push is hook-only via `emit_position_deltas` (see `homekit::start`).
+            self.execute_targets(&plan.targets).await?;
             for target in plan.targets {
                 statuses[target.index] = Some(CharacteristicWriteStatus::success(target.id));
             }


### PR DESCRIPTION
## Summary

- Route HomeKit position notifications through a one-shot `position_hook` on `BlindController::emit_position_deltas`, replacing the background `position_listener` task that subscribed to `subscribe_positions()`.
- Stop filling `CharacteristicWriteOutcome.events` on target-position writes so each delta batch is published once (hook only), avoiding duplicate HAP `EVENT/1.0` frames on the same PUT.
- Document the two live notification channels (selection `watch` vs position hook/broadcast) in `ARCHITECTURE.md` and clarify EVENT push in `HAP.md`.
- Add a debug log (`hap position events published`) to verify publish counts during Home/Siri testing.

## Motivation

Position updates already flowed through `position_tx`; HomeKit translated them in a separate async loop and writes could also push the same events via `outcome.events`. This consolidates publish timing at the point state changes and removes an extra task without changing the command or motion model.

## Test plan

- [x] `mise run check` (145 tests)
- [x] Manual Siri/Home session: one `hap position events published` per target PUT; separate `count=3` lines after timed motion completes (~`open_ms`/`close_ms`)
- [ ] Smoke on Pi with real driver after merge (optional)


Made with [Cursor](https://cursor.com)