### PR TITLE
Improve import clarity and tidy related tests

### DIFF
--- a/examples/render_unit.rs
+++ b/examples/render_unit.rs
@@ -1,3 +1,5 @@
+use somfy::commands::install;
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let user = args.first().map(String::as_str).unwrap_or("somfy-ci");
@@ -9,6 +11,6 @@ fn main() {
     let spi_device = args.get(3).map(String::as_str).unwrap_or("/dev/spidev0.0");
     print!(
         "{}",
-        somfy::commands::install::render_unit(user, exec, gpio_chip, spi_device)
+        install::render_unit(user, exec, gpio_chip, spi_device)
     );
 }

--- a/src/commands/doctor/hardware.rs
+++ b/src/commands/doctor/hardware.rs
@@ -7,6 +7,7 @@ use crate::config::RtsOptions;
 use crate::driver::{pigpiod_addr_list, pigpiod_addrs, PIGPIOD_PORT};
 use crate::gpio::{GpioOptions, MAX_BCM_GPIO};
 use crate::persist;
+use crate::rts::state::{RtsState, SCHEMA_VERSION, STATE_FILE};
 
 pub fn gpio_chip(options: &GpioOptions) -> Check {
     readable_file("gpio_chip_accessible", "GPIO", &options.chip)
@@ -56,7 +57,7 @@ fn pigpiod() -> Check {
 }
 
 fn rts_state_file() -> Check {
-    let path = persist::state_dir().join(crate::rts::state::STATE_FILE);
+    let path = persist::state_dir().join(STATE_FILE);
     let display = path.display().to_string();
     if !path.exists() {
         return Check::new("rts_state_file", "RTS state")
@@ -64,16 +65,15 @@ fn rts_state_file() -> Check {
             .detail(format!("{display} not yet created"));
     }
     match std::fs::read_to_string(&path) {
-        Ok(text) => match serde_json::from_str::<crate::rts::state::RtsState>(&text) {
-            Ok(state) if state.schema_version == crate::rts::state::SCHEMA_VERSION => {
+        Ok(text) => match serde_json::from_str::<RtsState>(&text) {
+            Ok(state) if state.schema_version == SCHEMA_VERSION => {
                 Check::new("rts_state_file", "RTS state").detail(display)
             }
             Ok(state) => Check::new("rts_state_file", "RTS state")
                 .status(Status::Blocking)
                 .detail(format!(
                     "{display}: schema_version {} unsupported (expected {})",
-                    state.schema_version,
-                    crate::rts::state::SCHEMA_VERSION
+                    state.schema_version, SCHEMA_VERSION
                 )),
             Err(e) => Check::new("rts_state_file", "RTS state")
                 .status(Status::Blocking)

--- a/src/commands/doctor/mod.rs
+++ b/src/commands/doctor/mod.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use check::Check;
 use serde::Serialize;
 
-use crate::config::DriverKind;
-use crate::config::ResolvedConfig;
+use crate::config::{DriverKind, ResolvedConfig};
+use crate::deploy;
 use crate::version;
 
 #[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
@@ -146,7 +146,7 @@ pub async fn collect(resolved_config: &ResolvedConfig, network_timeout_ms: u64) 
     let rendered_unit = systemd::render_expected_unit(resolved_config);
     checks.push(systemd::unit_installed());
 
-    let on_disk = std::fs::read_to_string(crate::deploy::UNIT_PATH).ok();
+    let on_disk = std::fs::read_to_string(deploy::UNIT_PATH).ok();
     match (&on_disk, &rendered_unit) {
         (Some(disk), Some(expected)) => {
             checks.push(systemd::unit_in_sync(disk, expected));

--- a/src/commands/remote.rs
+++ b/src/commands/remote.rs
@@ -1,24 +1,21 @@
 use anyhow::{bail, Context, Result};
 use futures_util::StreamExt;
-use std::path::PathBuf;
 
 use crate::cli::RemoteCommand;
-use crate::config::{self, ResolvedConfig};
+use crate::config::ResolvedConfig;
 use crate::core::Channel;
 use crate::server::base_url;
 use crate::service::{validate_command_request, CommandRequest};
 
-pub async fn run(command: RemoteCommand, config_path: Option<PathBuf>) -> Result<()> {
-    let resolved = config::resolve(config_path)?;
-
+pub async fn run(command: RemoteCommand, resolved: &ResolvedConfig) -> Result<()> {
     match command {
-        RemoteCommand::Up { channel } => post_command("up", channel, &resolved).await,
-        RemoteCommand::Down { channel } => post_command("down", channel, &resolved).await,
-        RemoteCommand::Stop { channel } => post_command("stop", channel, &resolved).await,
-        RemoteCommand::Select { channel } => post_command("select", Some(channel), &resolved).await,
+        RemoteCommand::Up { channel } => post_command("up", channel, resolved).await,
+        RemoteCommand::Down { channel } => post_command("down", channel, resolved).await,
+        RemoteCommand::Stop { channel } => post_command("stop", channel, resolved).await,
+        RemoteCommand::Select { channel } => post_command("select", Some(channel), resolved).await,
         RemoteCommand::Prog { channel, long } => {
             let cmd = if long { "prog_long" } else { "prog" };
-            post_command(cmd, Some(channel), &resolved).await
+            post_command(cmd, Some(channel), resolved).await
         }
         RemoteCommand::Status => status().await,
         RemoteCommand::Watch => watch().await,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -7,8 +7,8 @@ use crate::controller::BlindController;
 use crate::homekit;
 use crate::server::{serve, AppState};
 
-pub async fn run(resolved_config: ResolvedConfig) -> Result<()> {
-    let report = doctor::collect(&resolved_config, 0).await;
+pub async fn run(resolved_config: &ResolvedConfig) -> Result<()> {
+    let report = doctor::collect(resolved_config, 0).await;
     report.print_summary();
     if report.has_blocking_failure() {
         bail!("doctor reported blocking failures; refusing to start");

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use crate::cli::UpgradeChannel;
 use crate::commands::doctor;
 use crate::commands::install;
+use crate::config;
 use crate::deploy::{self, ServiceState, STAGED_DOWNLOAD};
 use crate::version;
 
@@ -110,8 +111,7 @@ pub async fn run(channel: UpgradeChannel, version_pin: Option<String>, check: bo
         }
     }
 
-    let resolved_config =
-        crate::config::resolve(None).context("loading config for unit refresh")?;
+    let resolved_config = config::resolve(None).context("loading config for unit refresh")?;
     let service_state = ServiceState::capture();
     let was_running = service_state.was_running();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,18 +275,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_homekit_flag() {
-        let config: AppConfig = toml::from_str(
-            r#"
-driver = "telis"
-homekit = false
-"#,
-        )
-        .unwrap();
-        assert!(!config.homekit);
-    }
-
-    #[test]
     fn parses_per_blind_positioning() {
         let config: AppConfig = toml::from_str(
             r#"

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -4,11 +4,11 @@ use std::fmt;
 use std::sync::Arc;
 use tokio::sync::{broadcast, Mutex};
 
-use crate::config::{DriverKind, PositioningOptions};
+use crate::config::{DriverConfig, DriverKind, PositioningOptions};
 use crate::core::{Channel, Command};
 use crate::driver::{CommandOutcome, CommandRouter, SelectedChannelRx};
 use crate::positioning::motion::{
-    plan_motion, BlindMovement, MotionPlan, MotionRequest, MotionTimings,
+    plan_motion, BlindMovement, DriverStart, MotionPlan, MotionRequest, MotionTimings,
 };
 use crate::positioning::motion_tasks::MotionTasks;
 use crate::positioning::state::{find_blind, BlindPosition, PositionCache, PositionDelta};
@@ -35,7 +35,7 @@ impl fmt::Debug for BlindController {
 
 impl BlindController {
     pub(crate) async fn with_driver(
-        config: crate::config::DriverConfig,
+        config: DriverConfig,
         positioning: PositioningOptions,
     ) -> Result<Self> {
         let driver_kind = config.kind;
@@ -54,7 +54,7 @@ impl BlindController {
 
     #[cfg(test)]
     pub(crate) async fn with_driver_and_positions_for_test(
-        config: crate::config::DriverConfig,
+        config: DriverConfig,
         positioning: PositioningOptions,
         positions: HashMap<u64, u8>,
     ) -> Result<Self> {
@@ -195,7 +195,7 @@ impl BlindController {
 
     async fn execute_travel(
         self: &Arc<Self>,
-        starts: Vec<crate::positioning::motion::DriverStart>,
+        starts: Vec<DriverStart>,
         movements: Vec<BlindMovement>,
     ) -> Result<Vec<PositionDelta>> {
         for movement in &movements {

--- a/src/controller/tests.rs
+++ b/src/controller/tests.rs
@@ -1,10 +1,12 @@
 use super::*;
+use crate::config::{DriverConfig, PositioningOptions};
+use crate::driver::ProtocolOperation;
 use crate::testing::fixtures::{fake_controller, uniform_positioning_l1_ms};
 use std::collections::HashMap;
 use tokio::time::{timeout, Duration};
 
-fn controller_config() -> crate::config::PositioningOptions {
-    crate::config::PositioningOptions::default()
+fn controller_config() -> PositioningOptions {
+    PositioningOptions::default()
 }
 
 #[test]
@@ -18,10 +20,9 @@ fn position_inference_only_tracks_directional_extremes() {
 
 #[tokio::test]
 async fn client_command_with_channel_targets_without_selection() {
-    let controller =
-        BlindController::with_driver(crate::config::DriverConfig::fake(), controller_config())
-            .await
-            .unwrap();
+    let controller = BlindController::with_driver(DriverConfig::fake(), controller_config())
+        .await
+        .unwrap();
 
     controller
         .execute(Command::Up, Some(Channel::L3))
@@ -32,7 +33,7 @@ async fn client_command_with_channel_targets_without_selection() {
     assert_eq!(controller.driver_kind(), DriverKind::Fake);
     assert_eq!(
         controller.operations(),
-        vec![crate::driver::ProtocolOperation::FakeCommand {
+        vec![ProtocolOperation::FakeCommand {
             channel: Channel::L3,
             command: Command::Up,
         }]
@@ -42,7 +43,7 @@ async fn client_command_with_channel_targets_without_selection() {
 #[tokio::test]
 async fn controller_operations_wait_behind_operation_lock() {
     let controller = Arc::new(
-        BlindController::with_driver(crate::config::DriverConfig::fake(), controller_config())
+        BlindController::with_driver(DriverConfig::fake(), controller_config())
             .await
             .unwrap(),
     );
@@ -67,7 +68,7 @@ async fn controller_operations_wait_behind_operation_lock() {
     operation.await.unwrap().unwrap();
     assert_eq!(
         controller.operations(),
-        vec![crate::driver::ProtocolOperation::FakeCommand {
+        vec![ProtocolOperation::FakeCommand {
             channel: Channel::L2,
             command: Command::Up,
         }]
@@ -96,7 +97,7 @@ async fn target_position_writes_wait_behind_operation_lock() {
     operation.await.unwrap().unwrap();
     assert_eq!(
         controller.operations(),
-        vec![crate::driver::ProtocolOperation::FakeCommand {
+        vec![ProtocolOperation::FakeCommand {
             channel: Channel::L1,
             command: Command::Down,
         }]
@@ -105,10 +106,9 @@ async fn target_position_writes_wait_behind_operation_lock() {
 
 #[tokio::test]
 async fn execute_on_rejects_select() {
-    let controller =
-        BlindController::with_driver(crate::config::DriverConfig::fake(), controller_config())
-            .await
-            .unwrap();
+    let controller = BlindController::with_driver(DriverConfig::fake(), controller_config())
+        .await
+        .unwrap();
 
     let err = controller
         .execute_on(Channel::L2, Command::Select)
@@ -171,7 +171,7 @@ async fn target_position_matching_pending_target_is_noop() {
     assert!(position_rx.try_recv().is_err());
     assert_eq!(
         controller.operations(),
-        vec![crate::driver::ProtocolOperation::FakeCommand {
+        vec![ProtocolOperation::FakeCommand {
             channel: Channel::L1,
             command: Command::Down,
         }]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -98,6 +98,7 @@ impl CommandRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rts::state::{RtsState, DEFAULT_RESERVE_SIZE, STATE_FILE};
 
     #[tokio::test]
     async fn rts_prog_transmits_pairing_waveform_without_changing_selection() {
@@ -130,7 +131,7 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let events = Arc::new(StdMutex::new(Vec::new()));
-        let state_path = dir.path().join(crate::rts::state::STATE_FILE);
+        let state_path = dir.path().join(STATE_FILE);
         let rts_driver = rts::RtsDriver::new_for_test(
             RtsOptions::default(),
             &state_path,
@@ -148,12 +149,12 @@ mod tests {
             *events.lock().expect("recording events mutex"),
             vec![Event::RtsTransmit(Channel::L3, RtsCommand::Prog)]
         );
-        let state: crate::rts::state::RtsState =
+        let state: RtsState =
             serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
         assert_eq!(state.selected_channel, Channel::L1);
         assert_eq!(
             state.channels.get(&Channel::L3).unwrap().reserved_until,
-            1 + crate::rts::state::DEFAULT_RESERVE_SIZE
+            1 + DEFAULT_RESERVE_SIZE
         );
         assert_eq!(state.channels.get(&Channel::L1).unwrap().reserved_until, 1);
     }

--- a/src/driver/rts.rs
+++ b/src/driver/rts.rs
@@ -13,6 +13,9 @@ use crate::rts::cc1101::Cc1101;
 use crate::rts::frame::{RtsCommand, RtsFrame};
 use crate::rts::pigpio::PigpioClient;
 use crate::rts::state::RtsStateStore;
+
+#[cfg(test)]
+use crate::rts::state::DEFAULT_RESERVE_SIZE;
 use crate::rts::waveform;
 
 /// pigpiod TCP port. The daemon is unauthenticated and must listen on loopback only.
@@ -128,8 +131,7 @@ impl RtsDriver {
         state_path: impl Into<std::path::PathBuf>,
         transmitter: Arc<dyn RtsTransmitter>,
     ) -> Result<Self> {
-        let state =
-            RtsStateStore::load_or_init(state_path, crate::rts::state::DEFAULT_RESERVE_SIZE)?;
+        let state = RtsStateStore::load_or_init(state_path, DEFAULT_RESERVE_SIZE)?;
         let selected_channel = state.selected_channel();
         let (sender, selected_rx) = watch::channel(selected_channel);
         Ok(Self::from_parts(
@@ -398,6 +400,7 @@ fn is_pigpio_io_error(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rts::state::{RtsState, DEFAULT_RESERVE_SIZE, STATE_FILE};
     use std::sync::Mutex as StdMutex;
 
     #[test]
@@ -436,7 +439,7 @@ mod tests {
     #[tokio::test]
     async fn execute_on_transmits_waveform_and_reserves_rolling_code() {
         let dir = tempfile::tempdir().unwrap();
-        let state_path = dir.path().join(crate::rts::state::STATE_FILE);
+        let state_path = dir.path().join(STATE_FILE);
         let transmitter = Arc::new(RecordingTransmitter::default());
         let driver =
             RtsDriver::new_for_test(RtsOptions::default(), &state_path, transmitter.clone())
@@ -453,19 +456,19 @@ mod tests {
         assert!(transmissions[0].remote_id > 0);
         assert_eq!(transmissions[0].pulses.len(), 508);
 
-        let state: crate::rts::state::RtsState =
+        let state: RtsState =
             serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
         assert_eq!(state.selected_channel, Channel::L1);
         assert_eq!(
             state.channels.get(&Channel::L3).unwrap().reserved_until,
-            1 + crate::rts::state::DEFAULT_RESERVE_SIZE
+            1 + DEFAULT_RESERVE_SIZE
         );
     }
 
     #[tokio::test]
     async fn select_updates_persisted_rts_selection_without_transmitting() {
         let dir = tempfile::tempdir().unwrap();
-        let state_path = dir.path().join(crate::rts::state::STATE_FILE);
+        let state_path = dir.path().join(STATE_FILE);
         let transmitter = Arc::new(RecordingTransmitter::default());
         let driver =
             RtsDriver::new_for_test(RtsOptions::default(), &state_path, transmitter.clone())
@@ -479,7 +482,7 @@ mod tests {
 
         assert_eq!(driver.selected_channel(), Channel::L4);
         assert!(transmitter.transmissions().is_empty());
-        let state: crate::rts::state::RtsState =
+        let state: RtsState =
             serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
         assert_eq!(state.selected_channel, Channel::L4);
     }

--- a/src/driver/telis.rs
+++ b/src/driver/telis.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use crate::config::TelisOptions;
 use crate::core::{Channel, Command};
 use crate::driver::{SelectedChannelRx, TELIS_PROG_UNAVAILABLE};
-use crate::gpio::{GpioOptions, TelisButton};
+use crate::gpio::{trigger_output, watch_inputs, GpioOptions, TelisButton};
 
 const MAX_SELECT_CYCLES: usize = 8;
 
@@ -129,7 +129,7 @@ impl TelisTransport for GpioTelisTransport {
     fn press(&self, button: TelisButton) -> BoxFuture<'_, Result<()>> {
         let gpio = Arc::clone(&self.gpio);
         let telis = Arc::clone(&self.options);
-        Box::pin(async move { crate::gpio::trigger_output(&gpio.chip, button, &telis.gpio).await })
+        Box::pin(async move { trigger_output(&gpio.chip, button, &telis.gpio).await })
     }
 
     fn select(&self) -> BoxFuture<'_, Result<Channel>> {
@@ -139,14 +139,12 @@ impl TelisTransport for GpioTelisTransport {
             let chip = gpio.chip.clone();
             let button_map = telis.gpio.clone();
             tokio::spawn(async move {
-                if let Err(e) =
-                    crate::gpio::trigger_output(&chip, TelisButton::Select, &button_map).await
-                {
+                if let Err(e) = trigger_output(&chip, TelisButton::Select, &button_map).await {
                     tracing::error!("failed to trigger Telis select button: {e}");
                 }
             });
 
-            crate::gpio::watch_inputs(&gpio.chip, &telis.gpio).await
+            watch_inputs(&gpio.chip, &telis.gpio).await
         })
     }
 }

--- a/src/homekit/mod.rs
+++ b/src/homekit/mod.rs
@@ -8,6 +8,8 @@ use crate::controller::BlindController;
 use crate::hap::mdns::{self, MdnsConfig};
 use crate::hap::runtime::{CharacteristicEvent, HapRuntime};
 use crate::hap::state::{FileHapStore, HapState};
+use crate::hap::{qr, server};
+use crate::persist;
 use crate::positioning::state::PositionDelta;
 
 mod accessory_db;
@@ -21,11 +23,11 @@ pub const HAP_CATEGORY: &str = "2";
 pub const MDNS_NAME_PREFIX: &str = "Somfy";
 
 pub fn store() -> FileHapStore {
-    FileHapStore::new(crate::persist::state_dir())
+    FileHapStore::new(persist::state_dir())
 }
 
 pub fn setup_uri(state: &HapState) -> Result<String> {
-    crate::hap::qr::setup_uri(state, HAP_CATEGORY)
+    qr::setup_uri(state, HAP_CATEGORY)
 }
 
 /// Handles for the background HomeKit tasks started by [`start`].
@@ -67,7 +69,7 @@ pub async fn start(controller: Arc<BlindController>) -> Result<HomekitHandles> {
     let position_events = spawn_position_events(controller, runtime.event_sender());
 
     let hap_server = tokio::spawn(async move {
-        if let Err(e) = crate::hap::server::serve(runtime, HAP_PORT).await {
+        if let Err(e) = server::serve(runtime, HAP_PORT).await {
             tracing::error!("HAP server exited: {}", e);
         }
     });

--- a/src/homekit/somfy.rs
+++ b/src/homekit/somfy.rs
@@ -152,7 +152,7 @@ fn position_for_aid(positions: &[BlindPosition], aid: u64) -> BlindPosition {
         .unwrap_or_else(|| BlindPosition::default_for_aid(aid))
 }
 
-fn build_accessories(positions: &[crate::positioning::state::BlindPosition]) -> Value {
+fn build_accessories(positions: &[BlindPosition]) -> Value {
     let blinds: Vec<BlindAccessory<'_>> = BLINDS
         .iter()
         .map(|blind| BlindAccessory {
@@ -169,6 +169,7 @@ fn build_accessories(positions: &[crate::positioning::state::BlindPosition]) -> 
 mod tests {
     use super::*;
     use crate::core::{Channel, Command};
+    use crate::driver::ProtocolOperation;
     use crate::positioning::state::STATUS_STOPPED;
     use crate::testing::fixtures::fake_four_blinds;
     use serde_json::json;
@@ -256,7 +257,7 @@ mod tests {
         assert!(outcome.all_success());
         assert_eq!(
             controller.operations(),
-            vec![crate::driver::ProtocolOperation::FakeCommand {
+            vec![ProtocolOperation::FakeCommand {
                 channel: Channel::L1,
                 command: Command::Down,
             }]
@@ -266,11 +267,11 @@ mod tests {
         assert_eq!(
             controller.operations(),
             vec![
-                crate::driver::ProtocolOperation::FakeCommand {
+                ProtocolOperation::FakeCommand {
                     channel: Channel::L1,
                     command: Command::Down,
                 },
-                crate::driver::ProtocolOperation::FakeCommand {
+                ProtocolOperation::FakeCommand {
                     channel: Channel::L1,
                     command: Command::Stop,
                 },
@@ -327,7 +328,7 @@ mod tests {
         assert!(outcome.all_success());
         assert_eq!(
             controller.operations(),
-            vec![crate::driver::ProtocolOperation::FakeCommand {
+            vec![ProtocolOperation::FakeCommand {
                 channel: Channel::All,
                 command: Command::Down,
             }]
@@ -354,7 +355,7 @@ mod tests {
 
         assert_eq!(
             controller.operations(),
-            vec![crate::driver::ProtocolOperation::FakeCommand {
+            vec![ProtocolOperation::FakeCommand {
                 channel: Channel::L1,
                 command: Command::Down,
             }]
@@ -393,11 +394,11 @@ mod tests {
         assert_eq!(
             controller.operations(),
             vec![
-                crate::driver::ProtocolOperation::FakeCommand {
+                ProtocolOperation::FakeCommand {
                     channel: Channel::L1,
                     command: Command::Down,
                 },
-                crate::driver::ProtocolOperation::FakeCommand {
+                ProtocolOperation::FakeCommand {
                     channel: Channel::L1,
                     command: Command::Stop,
                 },

--- a/src/homekit/target_writes.rs
+++ b/src/homekit/target_writes.rs
@@ -1,7 +1,7 @@
 //! HomeKit `TargetPosition` write planning and batch coalescing.
 
 use crate::hap::runtime::{
-    CharacteristicId, CharacteristicWrite, CharacteristicWriteStatus, HapStatus,
+    CharacteristicId, CharacteristicWrite, CharacteristicWriteStatus, HapStatus, Subscriptions,
 };
 use crate::homekit::accessory_db::IID_IDENTIFY;
 use crate::homekit::accessory_db::IID_TARGET_POSITION;
@@ -26,7 +26,7 @@ pub struct TargetWritePlan {
 
 pub fn plan_target_writes(
     writes: Vec<CharacteristicWrite>,
-    subscriptions: &mut crate::hap::runtime::Subscriptions,
+    subscriptions: &mut Subscriptions,
 ) -> TargetWritePlan {
     let mut statuses = Vec::new();
     let mut targets = Vec::new();
@@ -85,7 +85,7 @@ pub fn plan_target_writes(
 fn handle_subscription(
     id: CharacteristicId,
     enabled: bool,
-    subscriptions: &mut crate::hap::runtime::Subscriptions,
+    subscriptions: &mut Subscriptions,
 ) -> CharacteristicWriteStatus {
     if !is_known_characteristic(id) {
         return CharacteristicWriteStatus::error(id, HapStatus::ResourceDoesNotExist);
@@ -162,7 +162,7 @@ mod tests {
                 ev: None,
             })
             .collect::<Vec<_>>();
-        let mut subscriptions = crate::hap::runtime::Subscriptions::default();
+        let mut subscriptions = Subscriptions::default();
         let plan = plan_target_writes(writes, &mut subscriptions);
 
         assert_eq!(plan.targets.len(), 4);
@@ -189,7 +189,7 @@ mod tests {
             value: None,
             ev: Some(true),
         }];
-        let mut subscriptions = crate::hap::runtime::Subscriptions::default();
+        let mut subscriptions = Subscriptions::default();
 
         let plan = plan_target_writes(writes, &mut subscriptions);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,15 @@
 
 use anyhow::Result;
 use clap::Parser;
-use somfy::cli::{Cli, Command};
+use somfy::cli::{Cli, Command, ConfigCommand};
+use somfy::commands;
+use somfy::config;
+use somfy::logging;
 
 /// Single-threaded runtime: blind commands are serialized through the driver layer.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    somfy::logging::init();
+    logging::init();
 
     // rustls 0.23 requires an explicit crypto provider. Pin to `ring` so
     // `cargo-zigbuild` can cross-compile without pulling `aws-lc-rs`.
@@ -20,43 +23,43 @@ async fn main() -> Result<()> {
     let config_path = cli.config;
     match cli.command.unwrap_or(Command::Serve) {
         Command::Serve => {
-            let resolved_config = somfy::config::resolve(config_path)?;
-            somfy::commands::serve::run(resolved_config).await
+            let resolved_config = config::resolve(config_path)?;
+            commands::serve::run(resolved_config).await
         }
         Command::Install { user } => {
-            let resolved_config = somfy::config::resolve(config_path)?;
-            somfy::commands::install::run(user, &resolved_config)
+            let resolved_config = config::resolve(config_path)?;
+            commands::install::run(user, &resolved_config)
         }
         Command::Upgrade {
             channel,
             version,
             check,
-        } => somfy::commands::upgrade::run(channel, version, check).await,
+        } => commands::upgrade::run(channel, version, check).await,
         Command::Doctor { json, verbose } => {
-            let resolved_config = somfy::config::resolve(config_path)?;
-            somfy::commands::doctor::run(json, verbose, &resolved_config).await
+            let resolved_config = config::resolve(config_path)?;
+            commands::doctor::run(json, verbose, &resolved_config).await
         }
-        Command::Uninstall => somfy::commands::uninstall::run().await,
-        Command::Restart => somfy::commands::restart::run(),
-        Command::Remote { command } => somfy::commands::remote::run(command, config_path).await,
+        Command::Uninstall => commands::uninstall::run().await,
+        Command::Restart => commands::restart::run(),
+        Command::Remote { command } => commands::remote::run(command, config_path).await,
         Command::Homekit { command } => {
-            let resolved_config = somfy::config::resolve(config_path)?;
-            somfy::commands::homekit::run(command, &resolved_config)
+            let resolved_config = config::resolve(config_path)?;
+            commands::homekit::run(command, &resolved_config)
         }
-        Command::Logs(args) => somfy::commands::logs::run(args),
+        Command::Logs(args) => commands::logs::run(args),
         Command::Config { command } => match command {
-            somfy::cli::ConfigCommand::Path => {
-                let resolved_config = somfy::config::resolve(config_path)?;
-                somfy::commands::config::path(&resolved_config);
+            ConfigCommand::Path => {
+                let resolved_config = config::resolve(config_path)?;
+                commands::config::path(&resolved_config);
                 Ok(())
             }
-            somfy::cli::ConfigCommand::Show => {
-                let resolved_config = somfy::config::resolve(config_path)?;
-                somfy::commands::config::show(&resolved_config)
+            ConfigCommand::Show => {
+                let resolved_config = config::resolve(config_path)?;
+                commands::config::show(&resolved_config)
             }
-            somfy::cli::ConfigCommand::SetDriver { kind } => {
-                let resolved_config = somfy::config::resolve(config_path)?;
-                somfy::commands::config::set_driver(&resolved_config, kind)
+            ConfigCommand::SetDriver { kind } => {
+                let resolved_config = config::resolve(config_path)?;
+                commands::config::set_driver(&resolved_config, kind)
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,47 +20,28 @@ async fn main() -> Result<()> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let cli = Cli::parse();
-    let config_path = cli.config;
+    let resolved = config::resolve(cli.config)?;
     match cli.command.unwrap_or(Command::Serve) {
-        Command::Serve => {
-            let resolved_config = config::resolve(config_path)?;
-            commands::serve::run(resolved_config).await
-        }
-        Command::Install { user } => {
-            let resolved_config = config::resolve(config_path)?;
-            commands::install::run(user, &resolved_config)
-        }
+        Command::Serve => commands::serve::run(&resolved).await,
+        Command::Install { user } => commands::install::run(user, &resolved),
         Command::Upgrade {
             channel,
             version,
             check,
         } => commands::upgrade::run(channel, version, check).await,
-        Command::Doctor { json, verbose } => {
-            let resolved_config = config::resolve(config_path)?;
-            commands::doctor::run(json, verbose, &resolved_config).await
-        }
+        Command::Doctor { json, verbose } => commands::doctor::run(json, verbose, &resolved).await,
         Command::Uninstall => commands::uninstall::run().await,
         Command::Restart => commands::restart::run(),
-        Command::Remote { command } => commands::remote::run(command, config_path).await,
-        Command::Homekit { command } => {
-            let resolved_config = config::resolve(config_path)?;
-            commands::homekit::run(command, &resolved_config)
-        }
+        Command::Remote { command } => commands::remote::run(command, &resolved).await,
+        Command::Homekit { command } => commands::homekit::run(command, &resolved),
         Command::Logs(args) => commands::logs::run(args),
         Command::Config { command } => match command {
             ConfigCommand::Path => {
-                let resolved_config = config::resolve(config_path)?;
-                commands::config::path(&resolved_config);
+                commands::config::path(&resolved);
                 Ok(())
             }
-            ConfigCommand::Show => {
-                let resolved_config = config::resolve(config_path)?;
-                commands::config::show(&resolved_config)
-            }
-            ConfigCommand::SetDriver { kind } => {
-                let resolved_config = config::resolve(config_path)?;
-                commands::config::set_driver(&resolved_config, kind)
-            }
+            ConfigCommand::Show => commands::config::show(&resolved),
+            ConfigCommand::SetDriver { kind } => commands::config::set_driver(&resolved, kind),
         },
     }
 }

--- a/src/positioning/state.rs
+++ b/src/positioning/state.rs
@@ -3,7 +3,7 @@
 //! Reload is read-only: we never replay a saved position to GPIO.
 
 use anyhow::{Context, Result};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 use tokio::sync::Mutex;
@@ -242,7 +242,7 @@ fn load_positions_from(path: &Path) -> HashMap<u64, u8> {
 }
 
 fn save_positions_to(path: &Path, positions: &HashMap<u64, u8>) -> Result<()> {
-    let stringified: HashMap<String, u8> =
+    let stringified: BTreeMap<String, u8> =
         positions.iter().map(|(k, v)| (k.to_string(), *v)).collect();
     let bytes = serde_json::to_vec_pretty(&stringified)?;
     atomic_save_bytes(path, &bytes, false)
@@ -336,6 +336,20 @@ mod tests {
         save_positions_to(&path, &original).unwrap();
         let loaded = load_positions_from(&path);
         assert_eq!(loaded, original);
+    }
+
+    #[test]
+    fn positions_file_saves_in_stable_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(POSITIONS_FILE);
+        let positions = HashMap::from([(4, 37), (6, 50), (2, 0), (3, 101), (5, 100)]);
+
+        save_positions_to(&path, &positions).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "{\n  \"2\": 0,\n  \"3\": 101,\n  \"4\": 37,\n  \"5\": 100,\n  \"6\": 50\n}"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 use crate::controller::BlindController;
+use crate::embed;
 use crate::service::{dispatch_command, CommandError, CommandRequest};
 use anyhow::Result;
 use axum::extract::ws::{Message, WebSocket};
@@ -70,7 +71,7 @@ fn create_router(shared_state: Arc<AppState>) -> Router {
         .route("/events", get(handle_events))
         .route("/command", post(handle_command))
         .route("/ws", get(ws_handler))
-        .fallback(crate::embed::static_handler)
+        .fallback(embed::static_handler)
         .with_state(shared_state)
         .layer(cors)
         .layer(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -145,24 +145,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_accepts_select_with_channel() {
-        let req = parse("select", Some(Channel::L2)).unwrap();
-        assert_eq!(req.command, Command::Select);
-        assert_eq!(req.channel, Some(Channel::L2));
-    }
-
-    #[test]
-    fn parse_accepts_select_without_channel() {
-        let req = parse("select", None).unwrap();
-        assert_eq!(req.command, Command::Select);
-        assert_eq!(req.channel, None);
-    }
-
-    #[test]
-    fn parse_accepts_directional_channel() {
-        let req = parse("up", Some(Channel::L1)).unwrap();
-        assert_eq!(req.command, Command::Up);
-        assert_eq!(req.channel, Some(Channel::L1));
+    fn parse_accepts_valid_commands() {
+        for (wire, expected, channel) in [
+            ("select", Command::Select, Some(Channel::L2)),
+            ("select", Command::Select, None),
+            ("up", Command::Up, Some(Channel::L1)),
+            ("prog", Command::Prog, Some(Channel::L1)),
+            ("prog_long", Command::ProgLong, Some(Channel::L1)),
+        ] {
+            let req = parse(wire, channel).unwrap();
+            assert_eq!(req.command, expected, "{wire}");
+            assert_eq!(req.channel, channel, "{wire}");
+        }
     }
 
     #[test]
@@ -173,33 +167,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_accepts_prog_with_channel() {
-        let req = parse("prog", Some(Channel::L1)).unwrap();
-        assert_eq!(req.command, Command::Prog);
-        assert_eq!(req.channel, Some(Channel::L1));
-    }
-
-    #[test]
-    fn parse_accepts_prog_long_with_channel() {
-        let req = parse("prog_long", Some(Channel::L1)).unwrap();
-        assert_eq!(req.command, Command::ProgLong);
-        assert_eq!(req.channel, Some(Channel::L1));
-    }
-
-    #[test]
     fn command_request_accepts_channel_field() {
         let req: CommandRequest =
             serde_json::from_str(r#"{"command":"up","channel":"L1"}"#).unwrap();
 
         assert_eq!(req.command, "up");
-        assert_eq!(req.channel, Some(Channel::L1));
-    }
-
-    #[test]
-    fn command_request_accepts_prog_long() {
-        let req: CommandRequest =
-            serde_json::from_str(r#"{"command":"prog_long","channel":"L1"}"#).unwrap();
-        assert_eq!(req.command, "prog_long");
         assert_eq!(req.channel, Some(Channel::L1));
     }
 


### PR DESCRIPTION
## Summary

- Add module-level imports in `main.rs` and across the library so repeated `somfy::` / `crate::` paths read as short names (`ConfigCommand`, `commands::serve`, `DriverConfig`, RTS state constants, etc.).
- Save HomeKit position files in stable key order via `BTreeMap` and add a regression test for deterministic JSON output.
- Consolidate overlapping service/config parsing tests into parameterized cases and drop a duplicate HomeKit flag test.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test` (149 tests)


Made with [Cursor](https://cursor.com)