### PR TITLE
feat: Add target position remote command

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ The CLI has two modes:
 
 ### Transport Boundary
 
-Command requests are expressed in terms of `Channel` and `Command`: `L1`-`L4`, `ALL`, and actions such as `up`, `down`, `stop`, `select`, `prog`, and `prog_long`. Transport adapters are responsible for parsing protocol-specific input and returning protocol-specific output, but they should not implement hardware behavior.
+Command requests are expressed in terms of `Channel` and command intent. Channels are `L1`-`L4` and `ALL`. Direct button commands are `up`, `down`, `stop`, `select`, `prog`, and `prog_long`; percentage positioning uses `target` with a `value` from `0` to `100`. Transport adapters are responsible for parsing protocol-specific input and returning protocol-specific output, but they should not implement hardware behavior.
 
 Live state is pushed through:
 
@@ -108,7 +108,7 @@ The application core owns the rules that should be consistent across clients:
 - when selection changes are broadcast;
 - how inferred position updates are generated after movement commands.
 
-The system has no motor position sensors. Position is an application-level inference: successful `up` maps to open (`100`), successful `down` maps to closed (`0`), and `ALL` fans out to the individual channels so HomeKit remains consistent.
+The system has no motor position sensors. Position is an application-level inference: successful `up` maps to open (`100`), successful `down` maps to closed (`0`), and `target` moves from the cached current position to the requested percentage using configured travel times. `ALL` fans out to the individual channels so HomeKit and API clients remain consistent.
 
 ### Driver Boundary
 
@@ -133,7 +133,7 @@ sequenceDiagram
   participant Controller as Blind controller
   participant Driver as Active driver
 
-  UI->>HTTP: command + optional channel
+  UI->>HTTP: command + optional channel/value
   HTTP->>Controller: validate and execute client command
   Controller->>Driver: target channel or use selection
   Driver-->>Controller: success or error
@@ -141,7 +141,7 @@ sequenceDiagram
   Controller-->>UI: selection / position events
 ```
 
-The HTTP and WebSocket routes handle the client-facing request contract before dispatching to the controller. `select` changes the public selected channel. Movement and pairing commands with an explicit channel target that channel directly; movement commands without a channel use the current selection. Direct targeted controller calls reject `select` because selection is a client request, not a per-channel action.
+The HTTP and WebSocket routes handle the client-facing request contract before dispatching to the controller. Direct button requests use `{"command":"up","channel":"L2"}`; `channel` is optional for `up`, `down`, `stop`, and `select`, and omitted movement commands use the current selection. Target-position requests use `{"command":"target","value":50}` or `{"command":"target","channel":"L2","value":50}`. `select` changes the public selected channel. Movement, pairing, and target commands with an explicit channel target that channel directly. Direct targeted controller calls reject `select` because selection is a client request, not a per-channel action.
 
 ### HomeKit Command
 
@@ -166,7 +166,7 @@ sequenceDiagram
   Controller-->>HAP: EVENT current/stopped notification
 ```
 
-HomeKit exposes four `WindowCovering` accessories: `L1`-`L4`. Percentage writes use the controller's shared estimated-position engine because the motors provide no position feedback. Each blind has independent open/close timings under `positioning`; the controller sends a direction command, waits for the proportional travel time, sends `stop` only for interior targets (`1..99`), and persists the estimated current position. A write that matches cached current state is treated as a no-op, which prevents iOS from replaying stale target positions into physical movement after pairing or reconnect.
+HomeKit exposes four `WindowCovering` accessories: `L1`-`L4`. The HomeKit adapter translates target-position characteristic writes into controller target-position requests, then publishes the resulting position deltas back as HAP events. HAP protocol details and write semantics live in [HAP.md](HAP.md).
 
 ### RTS Transmission
 

--- a/docs/HAP.md
+++ b/docs/HAP.md
@@ -71,7 +71,7 @@ EVENT push is what resolves the iOS "Closing…" / "Opening…" spinner (waits o
 
 ## Timed positioning
 
-Somfy RTS/Telis motors do not report physical position, so percentages are estimated from configured travel time. The defaults are 10 seconds open and close for every blind. Override per blind:
+Somfy RTS/Telis motors do not report physical position, so percentages are estimated from configured travel time. These timings are used by HomeKit target-position writes and by the shared `target` command path. The defaults are 10 seconds open and close for every blind. Override per blind:
 
 ```toml
 [positioning.l1]
@@ -83,7 +83,7 @@ open_ms = 7000
 close_ms = 8000
 ```
 
-The controller supports different timings per blind. When Home writes all four blinds to the same direction in one batch, it can start them with one `ALL` command, then issue individual `stop` commands for interior targets at each blind's calculated completion time.
+The controller supports different timings per blind. Interior targets (`1..99`) schedule a proportional `stop`; endpoint targets (`0` and `100`) rely on the motor's own limits. When all four blinds move in the same direction in one request, the controller can start them with one `ALL` command, then issue individual `stop` commands for interior targets at each blind's calculated completion time.
 
 ## Lifecycle
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{value_parser, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 use crate::config::DriverKind;
@@ -96,6 +96,12 @@ pub enum RemoteCommand {
         /// the Pi is the master remote (RTS driver only).
         #[arg(long)]
         long: bool,
+    },
+    /// Move a channel to a target position percentage (0 = closed, 100 = open)
+    Target {
+        #[arg(value_parser = value_parser!(u8).range(0..=100))]
+        position: u8,
+        channel: Option<Channel>,
     },
     /// Print current selected channel
     Status,

--- a/src/commands/remote.rs
+++ b/src/commands/remote.rs
@@ -9,13 +9,18 @@ use crate::service::{validate_command_request, CommandRequest};
 
 pub async fn run(command: RemoteCommand, resolved: &ResolvedConfig) -> Result<()> {
     match command {
-        RemoteCommand::Up { channel } => post_command("up", channel, resolved).await,
-        RemoteCommand::Down { channel } => post_command("down", channel, resolved).await,
-        RemoteCommand::Stop { channel } => post_command("stop", channel, resolved).await,
-        RemoteCommand::Select { channel } => post_command("select", Some(channel), resolved).await,
+        RemoteCommand::Up { channel } => post_command("up", channel, None, resolved).await,
+        RemoteCommand::Down { channel } => post_command("down", channel, None, resolved).await,
+        RemoteCommand::Stop { channel } => post_command("stop", channel, None, resolved).await,
+        RemoteCommand::Select { channel } => {
+            post_command("select", Some(channel), None, resolved).await
+        }
         RemoteCommand::Prog { channel, long } => {
             let cmd = if long { "prog_long" } else { "prog" };
-            post_command(cmd, Some(channel), resolved).await
+            post_command(cmd, Some(channel), None, resolved).await
+        }
+        RemoteCommand::Target { position, channel } => {
+            post_command("target", channel, Some(position), resolved).await
         }
         RemoteCommand::Status => status().await,
         RemoteCommand::Watch => watch().await,
@@ -25,6 +30,7 @@ pub async fn run(command: RemoteCommand, resolved: &ResolvedConfig) -> Result<()
 async fn post_command(
     command: &'static str,
     channel: Option<Channel>,
+    value: Option<u8>,
     resolved: &ResolvedConfig,
 ) -> Result<()> {
     validate_command_request(
@@ -32,6 +38,7 @@ async fn post_command(
         CommandRequest {
             command: command.to_string(),
             channel,
+            value,
         },
     )?;
 
@@ -42,6 +49,7 @@ async fn post_command(
         .json(&CommandRequest {
             command: command.to_string(),
             channel,
+            value,
         })
         .send()
         .await

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -11,7 +11,9 @@ use crate::positioning::motion::{
     plan_motion, BlindMovement, DriverStart, MotionPlan, MotionRequest, MotionTimings,
 };
 use crate::positioning::motion_tasks::MotionTasks;
-use crate::positioning::state::{find_blind, BlindPosition, PositionCache, PositionDelta};
+use crate::positioning::state::{
+    find_blind, target_positions, BlindPosition, PositionCache, PositionDelta,
+};
 
 /// Driver-agnostic control of channel selection, button presses, and position events.
 pub struct BlindController {
@@ -121,6 +123,16 @@ impl BlindController {
             .into_iter()
             .find(|position| position.aid == aid)
             .unwrap_or_else(|| BlindPosition::default_for_aid(aid))
+    }
+
+    pub async fn set_target_for_channel(
+        self: &Arc<Self>,
+        channel: Option<Channel>,
+        position: u8,
+    ) -> Result<Vec<PositionDelta>> {
+        let channel = channel.unwrap_or_else(|| self.current_selection());
+        self.set_target_positions(target_positions(channel, position))
+            .await
     }
 
     pub async fn set_target_positions(

--- a/src/positioning/motion_tasks.rs
+++ b/src/positioning/motion_tasks.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tokio::sync::Mutex;
 
 use crate::core::Channel;
-use crate::positioning::state::BLINDS;
+use crate::positioning::state::aids_for_channel;
 
 #[derive(Debug, Default)]
 pub(crate) struct MotionTasks {
@@ -51,14 +51,7 @@ impl MotionTasks {
     }
 
     pub async fn cancel_channel(&self, channel: Channel) {
-        let aids: Vec<u64> = match channel {
-            Channel::All => BLINDS.iter().map(|blind| blind.aid).collect(),
-            _ => BLINDS
-                .iter()
-                .filter(|blind| blind.channel == channel)
-                .map(|blind| blind.aid)
-                .collect(),
-        };
+        let aids = aids_for_channel(channel);
         let mut tasks = self.tasks.lock().await;
         for aid in aids {
             Self::cancel_state(tasks.get_mut(&aid));

--- a/src/positioning/state.rs
+++ b/src/positioning/state.rs
@@ -56,6 +56,24 @@ pub fn find_blind(aid: u64) -> Option<&'static Blind> {
     BLINDS.iter().find(|b| b.aid == aid)
 }
 
+pub fn aids_for_channel(channel: Channel) -> Vec<u64> {
+    match channel {
+        Channel::All => BLINDS.iter().map(|blind| blind.aid).collect(),
+        _ => BLINDS
+            .iter()
+            .filter(|blind| blind.channel == channel)
+            .map(|blind| blind.aid)
+            .collect(),
+    }
+}
+
+pub fn target_positions(channel: Channel, position: u8) -> Vec<(u64, u8)> {
+    aids_for_channel(channel)
+        .into_iter()
+        .map(|aid| (aid, position))
+        .collect()
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BlindPosition {
     pub aid: u64,
@@ -358,5 +376,20 @@ mod tests {
         let path = dir.path().join(POSITIONS_FILE);
         let loaded = load_positions_from(&path);
         assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn aids_for_channel_maps_channel_and_all() {
+        assert_eq!(aids_for_channel(Channel::L2), vec![3]);
+        assert_eq!(aids_for_channel(Channel::All), vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn target_positions_pairs_aids_with_position() {
+        assert_eq!(target_positions(Channel::L2, 25), vec![(3, 25)]);
+        assert_eq!(
+            target_positions(Channel::All, 10),
+            vec![(2, 10), (3, 10), (4, 10), (5, 10)]
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -112,8 +112,13 @@ async fn handle_command(
 }
 
 async fn execute_command(state: &AppState, payload: CommandRequest) -> Result<(), String> {
-    tracing::info!(command = %payload.command, ?payload.channel, "remote command received");
-    dispatch_command(state.controller.as_ref(), payload)
+    tracing::info!(
+        command = %payload.command,
+        ?payload.channel,
+        ?payload.value,
+        "remote command received"
+    );
+    dispatch_command(&state.controller, payload)
         .await
         .map_err(map_command_error)?;
     tracing::info!("remote command completed");
@@ -176,12 +181,20 @@ async fn websocket(stream: WebSocket, state: Arc<AppState>, client_name: String,
                             Ok(payload) => {
                                 let command = payload.command.clone();
                                 let channel = payload.channel;
+                                let value = payload.value;
                                 let state = state.clone();
                                 let client_name = client_name.clone();
                                 tokio::spawn(async move {
                                     match execute_command(&state, payload).await {
                                         Ok(_) => {
-                                            tracing::info!("[{}:{}] {} {:?}", client_name, port, command, channel)
+                                            tracing::info!(
+                                                "[{}:{}] {} {:?} value={:?}",
+                                                client_name,
+                                                port,
+                                                command,
+                                                channel,
+                                                value
+                                            )
                                         }
                                         Err(e) => {
                                             tracing::error!(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::config::DriverKind;
 use crate::controller::BlindController;
@@ -11,9 +12,15 @@ use crate::driver::{CommandOutcome, TELIS_PROG_UNAVAILABLE};
 
 /// Parsed command ready for dispatch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ParsedCommandRequest {
-    pub command: Command,
-    pub channel: Option<Channel>,
+pub(crate) enum ParsedCommandRequest {
+    Driver {
+        command: Command,
+        channel: Option<Channel>,
+    },
+    Position {
+        channel: Option<Channel>,
+        position: u8,
+    },
 }
 
 /// HTTP/JSON command body (`POST /command`, WebSocket text, CLI remote POST).
@@ -22,6 +29,8 @@ pub(crate) struct ParsedCommandRequest {
 pub(crate) struct CommandRequest {
     pub command: String,
     pub channel: Option<Channel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,7 +56,22 @@ fn command_error(err: anyhow::Error) -> CommandError {
 
 /// Validate a command request. Does not touch hardware.
 fn parse_command(request: CommandRequest) -> Result<ParsedCommandRequest, CommandError> {
-    let CommandRequest { command, channel } = request;
+    let CommandRequest {
+        command,
+        channel,
+        value,
+    } = request;
+    if command == "target" {
+        let position = target_position_value(value)?;
+        return Ok(ParsedCommandRequest::Position { channel, position });
+    }
+
+    if value.is_some() {
+        return Err(CommandError::Invalid(
+            "value is only valid with target".to_string(),
+        ));
+    }
+
     let cmd = Command::from_str(&command).map_err(|e| CommandError::Invalid(e.to_string()))?;
     let channel = match (cmd, channel) {
         (Command::Prog | Command::ProgLong, Some(channel)) => Some(channel),
@@ -59,10 +83,20 @@ fn parse_command(request: CommandRequest) -> Result<ParsedCommandRequest, Comman
         (Command::Select, channel) => channel,
         (Command::Up | Command::Down | Command::Stop, channel) => channel,
     };
-    Ok(ParsedCommandRequest {
+    Ok(ParsedCommandRequest::Driver {
         command: cmd,
         channel,
     })
+}
+
+fn target_position_value(value: Option<u8>) -> Result<u8, CommandError> {
+    match value {
+        Some(position) if position <= 100 => Ok(position),
+        Some(_) => Err(CommandError::Invalid(
+            "target position must be between 0 and 100".to_string(),
+        )),
+        None => Err(CommandError::Invalid("target requires a value".to_string())),
+    }
 }
 
 /// Reject pairing commands when the active driver cannot transmit them.
@@ -79,32 +113,48 @@ pub(crate) fn validate_command_request(
     request: CommandRequest,
 ) -> Result<ParsedCommandRequest, CommandError> {
     let parsed = parse_command(request)?;
-    ensure_pairing_for_kind(kind, parsed.command)?;
+    if let ParsedCommandRequest::Driver { command, .. } = parsed {
+        ensure_pairing_for_kind(kind, command)?;
+    }
     Ok(parsed)
 }
 
 /// Validate and dispatch a command. `select` changes selection; action commands
 /// with an explicit channel target that channel directly.
 pub(crate) async fn dispatch_command(
-    controller: &BlindController,
+    controller: &Arc<BlindController>,
     request: CommandRequest,
 ) -> Result<CommandOutcome, CommandError> {
     let parsed = validate_command_request(controller.driver_kind(), request)?;
-    let ParsedCommandRequest {
-        command: cmd,
-        channel,
-    } = parsed;
-    controller
-        .execute(cmd, channel)
-        .await
-        .with_context(|| format!("executing {cmd:?} command"))
-        .map_err(command_error)
+    match parsed {
+        ParsedCommandRequest::Driver {
+            command: cmd,
+            channel,
+        } => controller
+            .execute(cmd, channel)
+            .await
+            .with_context(|| format!("executing {cmd:?} command"))
+            .map_err(command_error),
+        ParsedCommandRequest::Position { channel, position } => {
+            let channel = channel.unwrap_or_else(|| controller.current_selection());
+            controller
+                .set_target_for_channel(Some(channel), position)
+                .await
+                .with_context(|| format!("targeting {channel} to {position}%"))
+                .map_err(command_error)?;
+            Ok(CommandOutcome {
+                inferred_position: None,
+            })
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::DriverKind;
+    use crate::config::{DriverConfig, DriverKind, PositioningOptions};
+    use crate::driver::ProtocolOperation;
+    use std::sync::Arc;
 
     fn parse(
         command: &str,
@@ -113,6 +163,7 @@ mod tests {
         parse_command(CommandRequest {
             command: command.to_string(),
             channel,
+            value: None,
         })
     }
 
@@ -138,6 +189,7 @@ mod tests {
             CommandRequest {
                 command: "prog".to_string(),
                 channel: Some(Channel::L1),
+                value: None,
             },
         )
         .unwrap_err();
@@ -154,8 +206,14 @@ mod tests {
             ("prog_long", Command::ProgLong, Some(Channel::L1)),
         ] {
             let req = parse(wire, channel).unwrap();
-            assert_eq!(req.command, expected, "{wire}");
-            assert_eq!(req.channel, channel, "{wire}");
+            assert_eq!(
+                req,
+                ParsedCommandRequest::Driver {
+                    command: expected,
+                    channel
+                },
+                "{wire}"
+            );
         }
     }
 
@@ -173,6 +231,7 @@ mod tests {
 
         assert_eq!(req.command, "up");
         assert_eq!(req.channel, Some(Channel::L1));
+        assert_eq!(req.value, None);
     }
 
     #[test]
@@ -180,5 +239,105 @@ mod tests {
         let err = serde_json::from_str::<CommandRequest>(r#"{"command":"select","led":"L1"}"#)
             .unwrap_err();
         assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn parse_accepts_target_position_value() {
+        for body in [
+            r#"{"command":"target","channel":"L1","value":50}"#,
+            r#"{"command":"target","value":50}"#,
+        ] {
+            let req = serde_json::from_str::<CommandRequest>(body).unwrap();
+            let parsed = parse_command(req).unwrap();
+            assert!(matches!(
+                parsed,
+                ParsedCommandRequest::Position { position: 50, .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn parse_preserves_optional_target_channel() {
+        let with_channel = serde_json::from_str::<CommandRequest>(
+            r#"{"command":"target","channel":"L1","value":50}"#,
+        )
+        .unwrap();
+        let without_channel =
+            serde_json::from_str::<CommandRequest>(r#"{"command":"target","value":50}"#).unwrap();
+
+        assert_eq!(
+            parse_command(with_channel).unwrap(),
+            ParsedCommandRequest::Position {
+                channel: Some(Channel::L1),
+                position: 50,
+            }
+        );
+        assert_eq!(
+            parse_command(without_channel).unwrap(),
+            ParsedCommandRequest::Position {
+                channel: None,
+                position: 50,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_target_without_position() {
+        let req = serde_json::from_str::<CommandRequest>(r#"{"command":"target","channel":"L1"}"#)
+            .unwrap();
+
+        assert!(matches!(parse_command(req), Err(CommandError::Invalid(_))));
+    }
+
+    #[test]
+    fn parse_rejects_value_on_button_command() {
+        let req =
+            serde_json::from_str::<CommandRequest>(r#"{"command":"up","channel":"L1","value":50}"#)
+                .unwrap();
+
+        let err = parse_command(req).unwrap_err();
+        assert!(err.to_string().contains("value is only valid"));
+    }
+
+    #[test]
+    fn command_request_rejects_param_field() {
+        let err = serde_json::from_str::<CommandRequest>(r#"{"command":"target","param":50}"#)
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_target_without_channel_uses_current_selection() {
+        let controller = Arc::new(
+            BlindController::with_driver(DriverConfig::fake(), PositioningOptions::default())
+                .await
+                .unwrap(),
+        );
+        controller
+            .execute(Command::Select, Some(Channel::L2))
+            .await
+            .unwrap();
+
+        dispatch_command(
+            &controller,
+            CommandRequest {
+                command: "target".to_string(),
+                channel: None,
+                value: Some(50),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            controller.operations(),
+            vec![
+                ProtocolOperation::TelisSelection(Channel::L2),
+                ProtocolOperation::FakeCommand {
+                    channel: Channel::L2,
+                    command: Command::Down,
+                },
+            ]
+        );
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -136,11 +136,10 @@ pub(crate) async fn dispatch_command(
             .with_context(|| format!("executing {cmd:?} command"))
             .map_err(command_error),
         ParsedCommandRequest::Position { channel, position } => {
-            let channel = channel.unwrap_or_else(|| controller.current_selection());
             controller
-                .set_target_for_channel(Some(channel), position)
+                .set_target_for_channel(channel, position)
                 .await
-                .with_context(|| format!("targeting {channel} to {position}%"))
+                .with_context(|| format!("executing target position to {position}%"))
                 .map_err(command_error)?;
             Ok(CommandOutcome {
                 inferred_position: None,


### PR DESCRIPTION
## Summary

Adds a `target` command path for setting blinds to a percentage position from the CLI, HTTP API, and WebSocket API.

## Changes

- Add `somfy remote target <position> [channel]`, with `0..=100` validation.
- Accept API/WebSocket payloads such as `{"command":"target","value":50}` and `{"command":"target","channel":"L2","value":50}`.
- Route target requests through the shared controller positioning engine, using the current selection when `channel` is omitted.
- Move channel-to-accessory target mapping into the positioning layer and reuse it for motion cancellation.
- Update architecture and HAP docs to describe the final target-position command model.

## Validation

- `mise run check`