### PR TITLE
fix: motion stop and nightly update checks

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -35,15 +35,32 @@ pub async fn run(channel: UpgradeChannel, version_pin: Option<String>, check: bo
 
     if check {
         print_check(&release, &decision);
+        if decision.status == UpdateStatus::Unknown {
+            bail!(
+                "cannot determine whether {} is newer: {}",
+                release.tag_name,
+                decision.reason
+            );
+        }
         return Ok(());
     }
 
-    if !decision.newer {
-        println!(
-            "Already at {} ({}). Nothing to do.",
-            release.tag_name, decision.reason
-        );
-        return Ok(());
+    match decision.status {
+        UpdateStatus::Newer => {}
+        UpdateStatus::Current => {
+            println!(
+                "Already at {} ({}). Nothing to do.",
+                release.tag_name, decision.reason
+            );
+            return Ok(());
+        }
+        UpdateStatus::Unknown => {
+            bail!(
+                "cannot determine whether {} is newer: {}",
+                release.tag_name,
+                decision.reason
+            );
+        }
     }
 
     println!(
@@ -157,9 +174,9 @@ pub async fn run(channel: UpgradeChannel, version_pin: Option<String>, check: bo
 struct Release {
     tag_name: String,
     #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
     target_commitish: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
     assets: Vec<Asset>,
 }
 
@@ -201,8 +218,15 @@ async fn fetch_release(
     Ok(release)
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum UpdateStatus {
+    Newer,
+    Current,
+    Unknown,
+}
+
 struct Decision {
-    newer: bool,
+    status: UpdateStatus,
     reason: String,
 }
 
@@ -215,28 +239,37 @@ fn compare_versions(channel: UpgradeChannel, release: &Release) -> Decision {
                 semver::Version::parse(version::CRATE_VERSION),
             ) {
                 (Ok(latest), Ok(current)) => Decision {
-                    newer: latest > current,
+                    status: if latest > current {
+                        UpdateStatus::Newer
+                    } else {
+                        UpdateStatus::Current
+                    },
                     reason: format!("semver {current} vs {latest}"),
                 },
                 _ => Decision {
-                    newer: release.tag_name != format!("v{}", version::CRATE_VERSION),
+                    status: if release.tag_name != format!("v{}", version::CRATE_VERSION) {
+                        UpdateStatus::Newer
+                    } else {
+                        UpdateStatus::Current
+                    },
                     reason: "tag comparison (unparseable semver)".into(),
                 },
             }
         }
         UpgradeChannel::Nightly => {
-            let remote_sha = release
-                .target_commitish
-                .as_deref()
-                .or(release.name.as_deref())
-                .unwrap_or("");
+            let Some(remote_sha) = nightly_commit_sha(release) else {
+                return Decision {
+                    status: UpdateStatus::Unknown,
+                    reason: "release metadata does not contain a commit SHA".into(),
+                };
+            };
             let current = version::GIT_SHA;
-            let newer = !remote_sha.is_empty()
-                && !remote_sha.eq_ignore_ascii_case(current)
-                && !remote_sha.starts_with(current)
-                && !current.starts_with(remote_sha);
             Decision {
-                newer,
+                status: if same_git_commit(remote_sha, current) {
+                    UpdateStatus::Current
+                } else {
+                    UpdateStatus::Newer
+                },
                 reason: format!(
                     "git sha {} vs {}",
                     version::short_sha(),
@@ -245,6 +278,40 @@ fn compare_versions(channel: UpgradeChannel, release: &Release) -> Decision {
             }
         }
     }
+}
+
+fn nightly_commit_sha(release: &Release) -> Option<&str> {
+    // GitHub reports the moving release's target_commitish as the branch name
+    // (`main`); the release workflow writes the immutable commit into the body.
+    release
+        .body
+        .as_deref()
+        .and_then(|body| {
+            body.lines().find_map(|line| {
+                let candidate = line.trim().strip_prefix("Commit:")?.trim();
+                is_git_sha(candidate).then_some(candidate)
+            })
+        })
+        .or_else(|| {
+            release
+                .target_commitish
+                .as_deref()
+                .filter(|sha| is_git_sha(sha))
+        })
+}
+
+fn is_git_sha(value: &str) -> bool {
+    (7..=40).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn same_git_commit(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
+        || left
+            .get(..right.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(right))
+        || right
+            .get(..left.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(left))
 }
 
 fn asset_url(release: &Release, name: &str) -> Result<String> {
@@ -296,10 +363,12 @@ fn print_check(release: &Release, decision: &Decision) {
     );
     println!("Latest:  {}", release.tag_name);
     println!("{}", decision.reason);
-    if decision.newer {
-        println!("Newer version available. Run `sudo somfy upgrade` to apply.");
-    } else {
-        println!("Up to date.");
+    match decision.status {
+        UpdateStatus::Newer => {
+            println!("Newer version available. Run `sudo somfy upgrade` to apply.");
+        }
+        UpdateStatus::Current => println!("Up to date."),
+        UpdateStatus::Unknown => println!("Unable to determine update status."),
     }
 }
 
@@ -310,8 +379,8 @@ mod tests {
     fn release(tag: &str, target: Option<&str>, assets: &[(&str, &str)]) -> Release {
         Release {
             tag_name: tag.to_string(),
-            name: None,
             target_commitish: target.map(|s| s.to_string()),
+            body: None,
             assets: assets
                 .iter()
                 .map(|(n, u)| Asset {
@@ -326,21 +395,21 @@ mod tests {
     fn compare_versions_stable_newer() {
         let r = release("v9.9.9", None, &[]);
         let d = compare_versions(UpgradeChannel::Stable, &r);
-        assert!(d.newer, "expected newer: {}", d.reason);
+        assert_eq!(d.status, UpdateStatus::Newer, "{}", d.reason);
     }
 
     #[test]
     fn compare_versions_stable_same_not_newer() {
         let r = release(&format!("v{}", version::CRATE_VERSION), None, &[]);
         let d = compare_versions(UpgradeChannel::Stable, &r);
-        assert!(!d.newer, "expected not newer: {}", d.reason);
+        assert_eq!(d.status, UpdateStatus::Current, "{}", d.reason);
     }
 
     #[test]
     fn compare_versions_stable_unparseable_falls_back() {
         let r = release("not-semver", None, &[]);
         let d = compare_versions(UpgradeChannel::Stable, &r);
-        assert!(d.newer);
+        assert_eq!(d.status, UpdateStatus::Newer);
         assert!(d.reason.contains("tag comparison"));
     }
 
@@ -352,21 +421,44 @@ mod tests {
             &[],
         );
         let d = compare_versions(UpgradeChannel::Nightly, &r);
-        assert!(d.newer, "expected newer: {}", d.reason);
+        assert_eq!(d.status, UpdateStatus::Newer, "{}", d.reason);
     }
 
     #[test]
     fn compare_versions_nightly_same_sha_not_newer() {
         let r = release("nightly", Some(version::GIT_SHA), &[]);
         let d = compare_versions(UpgradeChannel::Nightly, &r);
-        assert!(!d.newer, "expected not newer: {}", d.reason);
+        assert_eq!(d.status, UpdateStatus::Current, "{}", d.reason);
     }
 
     #[test]
-    fn compare_versions_nightly_empty_remote_not_newer() {
-        let r = release("nightly", Some(""), &[]);
+    fn compare_versions_nightly_reads_commit_from_release_body() {
+        let mut r = release("nightly", Some("main"), &[]);
+        r.body = Some(format!(
+            "Moving prerelease from the main branch.\nCommit: {}\n",
+            version::GIT_SHA
+        ));
+
         let d = compare_versions(UpgradeChannel::Nightly, &r);
-        assert!(!d.newer);
+
+        assert_eq!(d.status, UpdateStatus::Current, "{}", d.reason);
+    }
+
+    #[test]
+    fn compare_versions_nightly_without_commit_is_unknown() {
+        let r = release("nightly", Some("main"), &[]);
+        let d = compare_versions(UpgradeChannel::Nightly, &r);
+
+        assert_eq!(d.status, UpdateStatus::Unknown);
+        assert!(d.reason.contains("does not contain a commit SHA"));
+    }
+
+    #[test]
+    fn nightly_commit_sha_rejects_non_hex_body_value() {
+        let mut r = release("nightly", Some("main"), &[]);
+        r.body = Some("Commit: not-a-sha".into());
+
+        assert_eq!(nightly_commit_sha(&r), None);
     }
 
     #[test]

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -286,11 +286,16 @@ impl BlindController {
         command: Command,
     ) -> (CommandOutcome, Vec<PositionDelta>) {
         let inferred_position = infer_position(command);
-        let deltas = if let Some(position) = inferred_position {
-            self.motion_tasks.cancel_channel(channel).await;
-            self.positions.apply_for_channel(channel, position).await
-        } else {
-            Vec::new()
+        let deltas = match (command, inferred_position) {
+            (_, Some(position)) => {
+                self.motion_tasks.cancel_channel(channel).await;
+                self.positions.apply_for_channel(channel, position).await
+            }
+            (Command::Stop, None) => {
+                self.motion_tasks.cancel_channel(channel).await;
+                self.positions.stop_channel(channel).await
+            }
+            _ => Vec::new(),
         };
         (CommandOutcome { inferred_position }, deltas)
     }

--- a/src/controller/tests.rs
+++ b/src/controller/tests.rs
@@ -181,6 +181,46 @@ async fn target_position_matching_pending_target_is_noop() {
 }
 
 #[tokio::test]
+async fn manual_stop_cancels_timed_position_completion() {
+    use crate::positioning::state::STATUS_STOPPED;
+
+    let controller =
+        fake_controller(uniform_positioning_l1_ms(100), HashMap::from([(2, 100)])).await;
+    controller
+        .set_target_positions(vec![(2, 50)])
+        .await
+        .unwrap();
+    let mut position_rx = controller.subscribe_positions();
+
+    controller
+        .execute(Command::Stop, Some(Channel::L1))
+        .await
+        .unwrap();
+    let published = position_rx.recv().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    assert_eq!(
+        controller.operations(),
+        vec![
+            ProtocolOperation::FakeCommand {
+                channel: Channel::L1,
+                command: Command::Down,
+            },
+            ProtocolOperation::FakeCommand {
+                channel: Channel::L1,
+                command: Command::Stop,
+            },
+        ]
+    );
+    let position = controller.position_for_aid(2).await;
+    assert_eq!(position.current, 100);
+    assert_eq!(position.target, 100);
+    assert_eq!(position.status, STATUS_STOPPED);
+    assert_eq!(published[0].target, Some(100));
+    assert_eq!(published[0].status, Some(STATUS_STOPPED));
+}
+
+#[tokio::test]
 async fn position_broadcast_runs_once_per_non_empty_emit() {
     let controller = fake_controller(controller_config(), HashMap::from([(2, 100)])).await;
     let mut position_rx = controller.subscribe_positions();

--- a/src/positioning/state.rs
+++ b/src/positioning/state.rs
@@ -209,6 +209,38 @@ impl PositionCache {
         target_events(blind.aid, target, status)
     }
 
+    /// Mark a manually stopped channel as stationary at its last known position.
+    ///
+    /// Position estimation only advances when a timed motion completes, so an
+    /// early stop cannot infer a more precise intermediate position. Resetting
+    /// the target to the last known current value keeps the state internally
+    /// consistent and prevents HomeKit from reporting a movement that is no
+    /// longer running.
+    pub async fn stop_channel(&self, channel: Channel) -> Vec<PositionDelta> {
+        let mut state = self.state.lock().await;
+        let mut deltas = Vec::new();
+
+        for aid in aids_for_channel(channel) {
+            let current = effective_current_position(&state, aid);
+            if effective_target_position(&state, aid) == current
+                && effective_status(&state, aid) == STATUS_STOPPED
+            {
+                continue;
+            }
+
+            state.target.insert(aid, current);
+            state.status.insert(aid, STATUS_STOPPED);
+            deltas.push(PositionDelta {
+                aid,
+                current: None,
+                target: Some(current),
+                status: Some(STATUS_STOPPED),
+            });
+        }
+
+        deltas
+    }
+
     fn finish_current_update(
         &self,
         changes: &[(u64, u8)],
@@ -332,6 +364,33 @@ mod tests {
         assert_eq!(blind.current, 25);
         assert_eq!(blind.target, 25);
         assert_eq!(blind.status, STATUS_STOPPED);
+    }
+
+    #[tokio::test]
+    async fn stop_channel_resets_pending_target_to_last_known_position() {
+        let cache = PositionCache::from_positions(HashMap::from([(2, 75)]));
+        cache.apply_target(&BLINDS[0], 25, STATUS_DECREASING).await;
+
+        let deltas = cache.stop_channel(Channel::L1).await;
+
+        assert_eq!(
+            deltas,
+            vec![PositionDelta {
+                aid: 2,
+                current: None,
+                target: Some(75),
+                status: Some(STATUS_STOPPED),
+            }]
+        );
+        assert_eq!(
+            cache.snapshot().await[0],
+            BlindPosition {
+                aid: 2,
+                current: 75,
+                target: 75,
+                status: STATUS_STOPPED,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cancel pending timed position completions when a manual stop command succeeds
- reconcile and broadcast the stopped target/status state using the last known position
- read the moving nightly release commit from the workflow-authored `Commit:` body line
- distinguish missing or malformed nightly metadata from an up-to-date release

## Why

A manual stop sent during a percentage move stopped the hardware but left the scheduled completion active. The timer could later send another stop and incorrectly snap the estimated position to the old target.

Nightly update checks compared the local SHA with `target_commitish` or the release name. The moving GitHub release reports the branch name (`main`) there, while the workflow publishes the immutable commit SHA in the release body. This made nightly checks report an update even when both builds were from the same commit, and missing metadata was treated as current.

## Impact

Manual stops now remain stopped in the shared position model and HomeKit receives the corrected target/status event. Nightly checks compare actual commit identities and fail safely when the release cannot be identified.

## Validation

- `mise run check` (formatting, frontend lint/typecheck, clippy with warnings denied, 179 tests)
- `mise run cross-build` (ARMv7 release build)
- `cargo run -- upgrade --channel nightly --check` (live release matched `ca0685d` and reported up to date)
- `git diff --check`